### PR TITLE
Fix global style issues that broke autoscrolling feature

### DIFF
--- a/src/components/PhotoGrid.astro
+++ b/src/components/PhotoGrid.astro
@@ -8,16 +8,6 @@ interface Props {
 const { images } = Astro.props;
 ---
 
-<style is:global>
-  /* 防止页面横向滚动 */
-  html, body {
-    overflow-x: hidden !important;
-    position: relative !important;
-    width: 100vw !important;
-    max-width: 100vw !important;
-  }
-</style>
-
 <div class="relative md:w-[400px] md:h-[300px] shrink-0">
   <!-- Mobile: 横向重叠三个圆 -->
   <div class="md:hidden relative w-screen h-[50vw] photo-carousel mt-12 mb-16" style="margin-left: calc(50% - 50vw); margin-right: calc(50% - 50vw); width: 100vw;">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,8 +3,8 @@
 @tailwind utilities;
 
 html {
-  overflow-y: scroll;
   color-scheme: light;
+  overflow-x: hidden;
   transition: none !important;
 }
 
@@ -14,12 +14,12 @@ html.dark {
 
 html,
 body {
-  @apply size-full overflow-x-hidden;
-  max-width: 100vw;
+  @apply w-full;
   position: relative;
 }
 
 body {
+  @apply min-h-screen;
   @apply font-sans antialiased;
   @apply flex flex-col;
   @apply bg-stone-100 dark:bg-stone-900;
@@ -115,18 +115,4 @@ img[src*="logo-light"] {
     color: inherit;
     text-decoration: none;
   }
-}
-
-/* 防止页面横向滚动 */
-html, body {
-  overflow-x: hidden;
-  position: relative;
-  width: 100%;
-  max-width: 100vw;
-}
-
-/* 确保内容不会超出视口宽度 */
-#app-container {
-  width: 100%;
-  overflow-x: clip;
 }


### PR DESCRIPTION
This pull request focuses on improving the handling of page layout and scroll behavior by consolidating styles and removing redundant or conflicting CSS rules. The changes simplify the CSS structure and ensure a consistent approach to preventing horizontal scrolling.

### Consolidation of global styles:

* Removed redundant inline `<style>` block in `src/components/PhotoGrid.astro` that applied global styles to prevent horizontal scrolling. These styles have been moved to a centralized location in `src/styles/global.css`.
* Updated `html` and `body` styles in `src/styles/global.css` to ensure consistent prevention of horizontal scrolling by using `overflow-x: hidden` and removing conflicting rules like `max-width: 100vw`. [[1]](diffhunk://#diff-03cc26efc9f06a95cd86aef185af462b72cc9d548a58177f8972837895f2de9eL6-R7) [[2]](diffhunk://#diff-03cc26efc9f06a95cd86aef185af462b72cc9d548a58177f8972837895f2de9eL17-R22)

### Simplification of layout rules:

* Removed outdated and redundant styles for `html` and `body` that were previously used to prevent horizontal scrolling, such as `position: relative` and `width: 100%`. These were replaced with cleaner and more concise rules.
* Added `min-h-screen` to the `body` to ensure the page content always spans the full height of the viewport, improving layout consistency.