### PR TITLE
Autoupdate year in footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -19,7 +19,7 @@ const t = useTranslations(lang);
     <div class="flex flex-col gap-1">
       <div class="flex justify-between items-center">
         <div>
-          &copy; 2024 {`•`} {SITE.NAME}
+          &copy; {new Date().getFullYear()} {`•`} {SITE.NAME}
         </div>
         <div class="flex flex-wrap gap-1 items-center">
           <button


### PR DESCRIPTION
This pull request updates the footer component to dynamically display the current year instead of a hardcoded value.

* [`src/components/Footer.astro`](diffhunk://#diff-9f7d7eae483a60a6aa76bcb68acc770e441d441ce02d414637694162983e6159L22-R22): Replaced the hardcoded year `2024` with `new Date().getFullYear()` to ensure the footer always reflects the current year.